### PR TITLE
Fix interval for WaveSequence

### DIFF
--- a/qubecalib/e7utils.py
+++ b/qubecalib/e7utils.py
@@ -132,9 +132,7 @@ class WaveSequenceTools:
         )
 
         s = IqWave.convert_to_iq_format(i, q, WaveSequence.NUM_SAMPLES_IN_WAVE_BLOCK)
-        total_duration_in_words = int(
-            i.shape[0] // WaveSequence.NUM_SAMPLES_IN_AWG_WORD
-        )
+        total_duration_in_words = int(len(s) // WaveSequence.NUM_SAMPLES_IN_AWG_WORD)
         wseq.add_chunk(
             iq_samples=s,
             num_blank_words=interval_words - total_duration_in_words,


### PR DESCRIPTION
Capture() の長さが 128 ns の整数倍でないと信号が観測できない問題を解消した．仮定した chunk 長の計算に誤りがあり，実際の chunk 長と齟齬があったために繰り返しする毎にバルスの位置がズレるというエラーだった．実際の chunk 長を元に計算するように直した．