### PR TITLE
[chore]: Replace os.getlogin with getpass.getuser

### DIFF
--- a/src/qubecalib/qubecalib.py
+++ b/src/qubecalib/qubecalib.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import pickle
 import time
+import getpass
 from collections import Counter, deque
 from dataclasses import asdict, dataclass, field
 from enum import Enum
@@ -1537,7 +1538,7 @@ class Executor:
             # もしコマンドキューに Sequencer が残っていれば次の Sequencer を実行する
             if isinstance(command, Sequencer):
                 status, iqs, config = next.execute(self._boxpool)
-                user_name = os.getlogin()
+                user_name = getpass.getuser()
                 current_pyfile = os.path.abspath(__file__)
                 date_time = datetime.datetime.now()
                 clock_ns = time.clock_gettime_ns(time.CLOCK_REALTIME)
@@ -1554,7 +1555,7 @@ class Executor:
                 return status, iqs, config
         # これ以上 Sequencer がなければ残りのコマンドを実行する
         status, iqs, config = next.execute(self._boxpool)
-        user_name = os.getlogin()
+        user_name = getpass.getuser()
         current_pyfile = os.path.abspath(__file__)
         date_time = datetime.datetime.now()
         clock_ns = time.clock_gettime_ns(time.CLOCK_REALTIME)


### PR DESCRIPTION
こちらのコメントに記載した内容のPRです。

https://github.com/qiqb-osaka/qube-calib-issues/issues/28


ローカルでCIで動かして`pytest`をPASSしていること確認しました。

```bash
| ============================= test session starts ==============================
| platform linux -- Python 3.9.19, pytest-8.3.2, pluggy-1.5.0
| rootdir: /Users/orangekame3/src/github.com/qiqb-osaka/qube-calib
| configfile: pyproject.toml
| plugins: mock-3.14.0, anyio-4.4.0
collected 47 items
|
| tests/unit/neopulse/test_arbit.py .....                                  [ 10%]
| tests/unit/neopulse/test_modifier.py ...                                 [ 17%]
| tests/unit/neopulse/test_padding.py .                                    [ 19%]
| tests/unit/neopulse/test_raised_cos_flat_top.py .....                    [ 29%]
| tests/unit/neopulse/test_rectangle.py .....                              [ 40%]
| tests/unit/neopulse/test_sequence.py ........                            [ 57%]
| tests/unit/neopulse/test_slot.py ....                                    [ 65%]
| tests/unit/neopulse/test_waveform.py .....                               [ 76%]
| tests/unit/qubecalib/test_qubecalib.py .........                         [ 95%]
| tests/unit/qubecalib/test_sequencer.py .                                 [ 97%]
| tests/unit/units/test_unit.py .                                          [100%]
|
| ============================== 47 passed in 0.70s ==============================
[Python package/build-1]   ✅  Success - Main Test with pytest
[Python package/build-1] ⭐ Run Post Set up Python 3.9
[Python package/build-1]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.4/arm64/bin/node /var/run/act/actions/actions-setup-python@v4/dist/cache-save/index.js] user= workdir=
[Python package/build-1]   ✅  Success - Post Set up Python 3.9
[Python package/build-1] Cleaning up container for job build
[Python package/build-1] 🏁  Job succeeded

```


### Additional Info

不要な修正(変更されると困る)などあればClose、もしくはご指摘お願いします。